### PR TITLE
Fixed the container mismatch with chart with css

### DIFF
--- a/src/docs/styles/custom.css
+++ b/src/docs/styles/custom.css
@@ -21,6 +21,10 @@ a:focus {
     color: '#FFFFFF';
 }
 
+.stacked-area-container {
+    display: flex;
+}
+
 /* Logo */
 .rsg--sidebar-4 .rsg--logo-5 {
     padding: 24px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Responsive container was not grabbing the right size, so to extend graph's layout, I just used `flex`. This will make sure the responsiveness stays and the chart occupies the whole given area.

## Motivation and Context
https://github.com/eventbrite/britecharts-react/issues/50

## How Has This Been Tested?
Ran demos, saw it looks good.

## Screenshots (if appropriate):
![screen shot 2017-11-30 at 5 23 52 pm](https://user-images.githubusercontent.com/31934144/33463652-9c0679ea-d5f3-11e7-842c-e77c4810e40e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
