### PR TITLE
Fix loading state styles

### DIFF
--- a/src/charts/bar/Bar.js
+++ b/src/charts/bar/Bar.js
@@ -9,7 +9,7 @@ class Bar extends Component {
         /**
          * Internally used, do not overwrite.
          */
-        data: PropTypes.arrayOf(PropTypes.any).isRequired,
+        data: PropTypes.arrayOf(PropTypes.any),
 
         /**
          * Gets or Sets the padding of the chart
@@ -162,12 +162,31 @@ class Bar extends Component {
         super(props);
 
         // We want to make this throw an error if no data is provided
-        if (!props.data) {
+        if (!props.data && !props.shouldShowLoadingState) {
             throw new Error('Data is required!');
         }
     }
 
     componentDidMount() {
+        if (this.props.data !== null) {
+            this._createChart();
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.data === null && this.props.data) {
+            this._createChart();
+        } else {
+            this._updateChart();
+            this.props.createTooltip();
+        }
+    }
+
+    componentWillUnmount() {
+        this.props.chart.destroy(this._rootNode);
+    }
+
+    _createChart() {
         this._chart = this.props.chart.create(
             this._rootNode,
             this.props.data,
@@ -175,19 +194,13 @@ class Bar extends Component {
         );
     }
 
-    componentDidUpdate() {
+    _updateChart() {
         this.props.chart.update(
             this._rootNode,
             this.props.data,
             this._getChartConfiguration(),
             this._chart
         );
-
-        this.props.createTooltip();
-    }
-
-    componentWillUnmount() {
-        this.props.chart.destroy(this._rootNode);
     }
 
     /**
@@ -213,7 +226,7 @@ class Bar extends Component {
 
         return loadingContainerWrapper(
             this.props,
-            this.props.chart.loading(),
+            this.props.loadingState || this.props.chart.loading(),
             <div className="bar-container" ref={this._setRef.bind(this)} />
         );
     }

--- a/src/charts/bar/Bar.js
+++ b/src/charts/bar/Bar.js
@@ -158,15 +158,6 @@ class Bar extends Component {
         shouldShowLoadingState: false,
     }
 
-    constructor(props) {
-        super(props);
-
-        // We want to make this throw an error if no data is provided
-        if (!props.data && !props.shouldShowLoadingState) {
-            throw new Error('Data is required!');
-        }
-    }
-
     componentDidMount() {
         if (this.props.data !== null) {
             this._createChart();

--- a/src/charts/bar/Bar.js
+++ b/src/charts/bar/Bar.js
@@ -159,17 +159,19 @@ class Bar extends Component {
     }
 
     componentDidMount() {
-        if (this.props.data !== null) {
+        if (!this.props.shouldShowLoadingState) {
             this._createChart();
         }
     }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.data === null && this.props.data) {
-            this._createChart();
-        } else {
-            this._updateChart();
-            this.props.createTooltip();
+    componentDidUpdate() {
+        if (!this.props.shouldShowLoadingState) {
+            if (!this._chart) {
+                this._createChart();
+            } else {
+                this._updateChart();
+                this.props.createTooltip();
+            }
         }
     }
 

--- a/src/charts/bar/Bar.test.js
+++ b/src/charts/bar/Bar.test.js
@@ -13,12 +13,6 @@ describe('Bar Chart', () => {
 
     describe('render', () => {
 
-        describe('when data is not passed', () => {
-            it('should throw an error', () => {
-                expect(() => shallow(<Bar data={[]} />)).toThrow();
-            });
-        });
-
         describe('when data passed in', () => {
             let createSpy;
 

--- a/src/charts/bar/Readme.md
+++ b/src/charts/bar/Readme.md
@@ -33,6 +33,16 @@
     />
 ```
 
+### With loading state
+```js
+
+    <Bar
+        data={null}
+        shouldShowLoadingState={true}
+    />
+```
+
+
 See more:
 * [API description][APILink]
 * [Data definition][DataLink]

--- a/src/charts/bar/barChart.test.js
+++ b/src/charts/bar/barChart.test.js
@@ -23,19 +23,6 @@ describe('Bar Chart', () => {
                     }).toThrowError('A root container is required');
                 });
             });
-
-            describe('when the Data is not passed', () => {
-                it('should throw an error with undefined data', () => {
-                    expect(() => {
-                        bar.create(
-                            anchor,
-                            undefined,
-                            {}
-                        );
-                    }).toThrowError('Data must be defined');
-                });
-            });
-
             describe('when a non-supported method is passed', () => {
                 it('should throw an error', () => {
                     expect(() => {

--- a/src/charts/donut/Donut.js
+++ b/src/charts/donut/Donut.js
@@ -9,7 +9,7 @@ export default class Donut extends Component {
         /**
          * Internally used, do not overwrite.
          */
-        data: PropTypes.array.isRequired,
+        data: PropTypes.array,
 
         /**
          * Gets or Sets the colorSchema of the chart
@@ -92,12 +92,30 @@ export default class Donut extends Component {
         super(props);
 
         // We want to make this throw an error if no data is provided
-        if (!props.data) {
+        if (!props.data && !props.shouldShowLoadingState) {
             throw new Error('Data is required!');
         }
     }
 
     componentDidMount() {
+        if (this.props.data !== null) {
+            this._createChart();
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.data === null && this.props.data) {
+            this._createChart();
+        } else {
+            this._updateChart();
+        }
+    }
+
+    componentWillUnmount() {
+        this.props.chart.destroy(this._rootNode);
+    }
+
+    _createChart() {
         this._chart = this.props.chart.create(
             this._rootNode,
             this.props.data,
@@ -105,17 +123,13 @@ export default class Donut extends Component {
         );
     }
 
-    componentDidUpdate() {
+    _updateChart() {
         this.props.chart.update(
             this._rootNode,
             this.props.data,
             this._getChartConfiguration(),
             this._chart
         );
-    }
-
-    componentWillUnmount() {
-        this.props.chart.destroy(this._rootNode);
     }
 
     /**
@@ -137,10 +151,9 @@ export default class Donut extends Component {
     }
 
     render() {
-
         return loadingContainerWrapper(
             this.props,
-            this.props.chart.loading(),
+            this.props.loadingState || this.props.chart.loading(),
             <div className="donut-container" ref={this._setRef.bind(this)} />
         );
     }

--- a/src/charts/donut/Donut.js
+++ b/src/charts/donut/Donut.js
@@ -89,16 +89,18 @@ export default class Donut extends Component {
     }
 
     componentDidMount() {
-        if (this.props.data !== null) {
+        if (!this.props.shouldShowLoadingState) {
             this._createChart();
         }
     }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.data === null && this.props.data) {
-            this._createChart();
-        } else {
-            this._updateChart();
+    componentDidUpdate() {
+        if (!this.props.shouldShowLoadingState) {
+            if (!this._chart) {
+                this._createChart();
+            } else {
+                this._updateChart();
+            } 
         }
     }
 

--- a/src/charts/donut/Donut.js
+++ b/src/charts/donut/Donut.js
@@ -88,15 +88,6 @@ export default class Donut extends Component {
         shouldShowLoadingState: false,
     }
 
-    constructor(props) {
-        super(props);
-
-        // We want to make this throw an error if no data is provided
-        if (!props.data && !props.shouldShowLoadingState) {
-            throw new Error('Data is required!');
-        }
-    }
-
     componentDidMount() {
         if (this.props.data !== null) {
             this._createChart();

--- a/src/charts/donut/Donut.test.js
+++ b/src/charts/donut/Donut.test.js
@@ -13,12 +13,6 @@ describe('Donut Chart', () => {
 
     describe('render', () => {
 
-        describe('when data is not passed', () => {
-            it('should throw an error', () => {
-                expect(() => shallow(<Donut />)).toThrow();
-            });
-        });
-
         describe('when data passed in', () => {
             let createSpy;
 

--- a/src/charts/donut/Readme.md
+++ b/src/charts/donut/Readme.md
@@ -38,6 +38,15 @@
 ```
 
 
+### With loading state
+```js
+
+    <Donut
+        data={null}
+        shouldShowLoadingState={true}
+    />
+```
+
 See more:
 * [API description][APILink]
 * [Data definition][DataLink]

--- a/src/charts/donut/Readme.md
+++ b/src/charts/donut/Readme.md
@@ -42,7 +42,7 @@
 ```js
 
     <Donut
-        data={null}
+        data={[]}
         shouldShowLoadingState={true}
     />
 ```

--- a/src/charts/donut/donutChart.test.js
+++ b/src/charts/donut/donutChart.test.js
@@ -24,18 +24,6 @@ describe('Donut Chart', () => {
                 });
             });
 
-            describe('when the Data is not passed', () => {
-                it('should throw an error with undefined data', () => {
-                    expect(() => {
-                        donut.create(
-                            anchor,
-                            undefined,
-                            {}
-                        );
-                    }).toThrowError('Data must be defined');
-                });
-            });
-
             describe('when a non-supported method is passed', () => {
                 it('should throw an error', () => {
                     expect(() => {

--- a/src/charts/helpers/validation.js
+++ b/src/charts/helpers/validation.js
@@ -21,8 +21,4 @@ export const validateContainer = (container) => {
     }
 };
 
-export const validateData = (data) => {
-    if (!data) {
-        throw Error('Data must be defined');
-    }
-};
+export const validateData = (data) => {};

--- a/src/charts/legend/Legend.js
+++ b/src/charts/legend/Legend.js
@@ -65,15 +65,6 @@ export default class Legend extends React.Component {
         chart: PropTypes.object,
     }
 
-    constructor(props) {
-        super(props);
-
-        // We want to make this throw an error if no data is provided
-        if (!props.data) {
-            throw new Error('Data is required!');
-        }
-    }
-
     componentDidMount() {
         this._chart = this.props.chart.create(
             this._rootNode,

--- a/src/charts/legend/Legend.test.js
+++ b/src/charts/legend/Legend.test.js
@@ -13,12 +13,6 @@ describe('Legend Chart', () => {
 
     describe('render', () => {
 
-        describe('when data is not passed', () => {
-            it('should throw an error', () => {
-                expect(() => shallow(<Legend data={[]} />)).toThrow();
-            });
-        });
-
         describe('when data passed in', () => {
             let createSpy;
 

--- a/src/charts/legend/LegendChart.test.js
+++ b/src/charts/legend/LegendChart.test.js
@@ -24,18 +24,6 @@ describe('Legend Chart', () => {
                 });
             });
 
-            describe('when the Data is not passed', () => {
-                it('should throw an error with undefined data', () => {
-                    expect(() => {
-                        legendChart.create(
-                            anchor,
-                            undefined,
-                            {}
-                        );
-                    }).toThrowError('Data must be defined');
-                });
-            });
-
             describe('when a non-supported method is passed', () => {
                 it('should throw an error', () => {
                     expect(() => {

--- a/src/charts/legend/legendChart.test.js
+++ b/src/charts/legend/legendChart.test.js
@@ -24,18 +24,6 @@ describe('Legend Chart', () => {
                 });
             });
 
-            describe('when the Data is not passed', () => {
-                it('should throw an error with undefined data', () => {
-                    expect(() => {
-                        legendChart.create(
-                            anchor,
-                            undefined,
-                            {}
-                        );
-                    }).toThrowError('Data must be defined');
-                });
-            });
-
             describe('when a non-supported method is passed', () => {
                 it('should throw an error', () => {
                     expect(() => {

--- a/src/charts/line/Line.js
+++ b/src/charts/line/Line.js
@@ -165,32 +165,45 @@ class Line extends React.Component {
         super(props);
 
         // We want to make this throw an error if no data is provided
-        if (!props.data) {
+        if (!props.data && !props.shouldShowLoadingState) {
             throw new Error('Data is required!');
         }
     }
 
     componentDidMount() {
+        if (this.props.data !== null) {
+            this._createChart();
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.data === null && this.props.data) {
+            this._createChart();
+        } else {
+            this._updateChart();
+            this.props.createTooltip();
+        }
+    }
+
+    componentWillUnmount() {
+        this.props.chart.destroy(this._rootNode);
+    }
+
+    _createChart() {
         this._chart = this.props.chart.create(
             this._rootNode,
             this.props.data,
             this._getChartConfiguration()
         );
-
     }
 
-    componentDidUpdate() {
+    _updateChart() {
         this.props.chart.update(
             this._rootNode,
             this.props.data,
             this._getChartConfiguration(),
             this._chart
         );
-        this.props.createTooltip();
-    }
-
-    componentWillUnmount() {
-        this.props.chart.destroy(this._rootNode);
     }
 
     /**
@@ -213,10 +226,9 @@ class Line extends React.Component {
     }
 
     render() {
-
         return loadingContainerWrapper(
             this.props,
-            this.props.chart.loading(),
+            this.props.loadingState || this.props.chart.loading(),
             <div className="line-container" ref={this._setRef.bind(this)} />
         );
     }

--- a/src/charts/line/Line.js
+++ b/src/charts/line/Line.js
@@ -161,15 +161,6 @@ class Line extends React.Component {
         shouldShowLoadingState: false,
     }
 
-    constructor(props) {
-        super(props);
-
-        // We want to make this throw an error if no data is provided
-        if (!props.data && !props.shouldShowLoadingState) {
-            throw new Error('Data is required!');
-        }
-    }
-
     componentDidMount() {
         if (this.props.data !== null) {
             this._createChart();

--- a/src/charts/line/Line.js
+++ b/src/charts/line/Line.js
@@ -162,17 +162,19 @@ class Line extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.data !== null) {
+        if (!this.props.shouldShowLoadingState) {
             this._createChart();
         }
     }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.data === null && this.props.data) {
-            this._createChart();
-        } else {
-            this._updateChart();
-            this.props.createTooltip();
+    componentDidUpdate() {
+        if (!this.props.shouldShowLoadingState) {
+            if (!this._chart) {
+                this._createChart();
+            } else {
+                this._updateChart();
+                this.props.createTooltip();
+            }
         }
     }
 

--- a/src/charts/line/Line.test.js
+++ b/src/charts/line/Line.test.js
@@ -12,13 +12,7 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('Line Chart', () => {
 
     describe('render', () => {
-
-        describe('when data is not passed', () => {
-            it('should throw an error', () => {
-                expect(() => shallow(<Line data={{}} />)).toThrow();
-            });
-        });
-
+        
         describe('when data passed in', () => {
             let createSpy;
 

--- a/src/charts/line/Readme.md
+++ b/src/charts/line/Readme.md
@@ -42,7 +42,6 @@
         <Line
             tooltipThreshold={0}
             margin={margin}
-            shouldShowLoadingState={true}
             {...props}
         />
     );

--- a/src/charts/line/Readme.md
+++ b/src/charts/line/Readme.md
@@ -77,6 +77,15 @@
     />
 ```
 
+### With loading state
+```js
+
+    <Line
+        data={null}
+        shouldShowLoadingState={true}
+    />
+```
+
 See more:
 * [API description][APILink]
 * [Data definition][DataLink]

--- a/src/charts/line/lineChart.test.js
+++ b/src/charts/line/lineChart.test.js
@@ -24,18 +24,6 @@ describe('Bar Chart', () => {
                 });
             });
 
-            describe('when the Data is not passed', () => {
-                it('should throw an error with undefined data', () => {
-                    expect(() => {
-                        line.create(
-                            anchor,
-                            undefined,
-                            {}
-                        );
-                    }).toThrowError('Data must be defined');
-                });
-            });
-
             describe('when a non-supported method is passed', () => {
                 it('should throw an error', () => {
                     expect(() => {

--- a/src/charts/loading/LoadingContainer.js
+++ b/src/charts/loading/LoadingContainer.js
@@ -8,6 +8,7 @@ export const loadingContainerWrapper = ({data, height, shouldShowLoadingState, w
                 data={data}
                 height={height}
                 loadingState={loadingState}
+                shouldShowLoadingState={shouldShowLoadingState}
                 width={width}
             >
                 {container}
@@ -16,8 +17,6 @@ export const loadingContainerWrapper = ({data, height, shouldShowLoadingState, w
     }
     return container;
 };
-
-const toggleLoading = (state) => ({loading: !state.loading});
 
 export default class LoadingContainer extends PureComponent {
     static propTypes = {
@@ -31,56 +30,38 @@ export default class LoadingContainer extends PureComponent {
         loadingState: PropTypes.string,
     }
 
-    state = {
-        loading: true,
-    }
-
-    componentDidMount() {
-        if (this.props.data !== null) {
-            this.setState(toggleLoading);
-        }
-    }
-
-    componentWillReceiveProps(nextProps) {
-        if (this.props.data === null && nextProps.data !== null) {
-            this.setState(toggleLoading);
-        }
-    }
-
     render() {
         const {
             children,
             height,
             loadingState,
+            shouldShowLoadingState,
             width,
         } = this.props;
         const chartStyles = {};
 
-        if (this.state.loading) {
+        if (shouldShowLoadingState) {
             chartStyles.display = 'none';
         }
 
-        let chart = (
-            <div className="loading-container__children" style={chartStyles}>
-                {children}
-            </div>
+        let loadingContainer = (
+            <div
+                className="loading-container__svg-container"
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{ __html: loadingState }}
+                style={{
+                    width: width || '100%',
+                    height: height || '100%',
+                }}
+            />
         );
 
         return (
             <div>
-                {
-                    this.state.loading && 
-                        <div
-                            className="loading-container__svg-container"
-                            // eslint-disable-next-line react/no-danger
-                            dangerouslySetInnerHTML={{ __html: loadingState }}
-                            style={{
-                                width: width || '100%',
-                                height: height || '100%',
-                            }}
-                        />
-                }
-                {chart}
+                {shouldShowLoadingState && loadingContainer}
+                <div className="loading-container__children" style={chartStyles}>
+                    {children}
+                </div>
             </div>
         );
     }

--- a/src/charts/loading/LoadingContainer.js
+++ b/src/charts/loading/LoadingContainer.js
@@ -1,12 +1,14 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 
-export const loadingContainerWrapper = ({data, shouldShowLoadingState}, loadingState, container) => {
+export const loadingContainerWrapper = ({data, height, shouldShowLoadingState, width}, loadingState, container) => {
     if (shouldShowLoadingState) {
         container = (
             <LoadingContainer
                 data={data}
+                height={height}
                 loadingState={loadingState}
+                width={width}
             >
                 {container}
             </LoadingContainer>
@@ -48,33 +50,36 @@ export default class LoadingContainer extends PureComponent {
     render() {
         const {
             children,
+            height,
             loadingState,
+            width,
         } = this.props;
         const chartStyles = {};
 
         if (this.state.loading) {
-            chartStyles.visibility = 'hidden';
+            chartStyles.display = 'none';
         }
 
+        let chart = (
+            <div className="loading-container__children" style={chartStyles}>
+                {children}
+            </div>
+        );
+
         return (
-            <div style={{position: 'relative'}}>
+            <div>
                 {
                     this.state.loading && 
                         <div
                             className="loading-container__svg-container"
                             dangerouslySetInnerHTML={{ __html: loadingState }}
                             style={{
-                                width: '100%',
-                                height: '100%',
-                                top: 0,
-                                left: 0,
-                                position: 'absolute',
+                                width: width || '100%',
+                                height: height || '100%',
                             }}
                         />
                 }
-                <div className="loading-container__children" style={chartStyles}>
-                    {children}
-                </div>
+                {chart}
             </div>
         );
     }

--- a/src/charts/loading/LoadingContainer.js
+++ b/src/charts/loading/LoadingContainer.js
@@ -72,6 +72,7 @@ export default class LoadingContainer extends PureComponent {
                     this.state.loading && 
                         <div
                             className="loading-container__svg-container"
+                            // eslint-disable-next-line react/no-danger
                             dangerouslySetInnerHTML={{ __html: loadingState }}
                             style={{
                                 width: width || '100%',

--- a/src/charts/loading/LoadingContainer.test.js
+++ b/src/charts/loading/LoadingContainer.test.js
@@ -80,8 +80,6 @@ describe('Loading Container', () => {
 
                 let childContainer = wrapper.find('.loading-container__children');
 
-                console.log(childContainer.html());
-
                 let actual = childContainer.html().match(/style="([^"]*)"/i)[1];
 
                 expect(actual).toEqual(expected);

--- a/src/charts/loading/LoadingContainer.test.js
+++ b/src/charts/loading/LoadingContainer.test.js
@@ -51,7 +51,7 @@ describe('Loading Container', () => {
 
         });
 
-        describe('when data is null', () => {
+        describe('when shouldShowLoadingState is passed', () => {
             let wrapper;
 
             beforeEach(() => {
@@ -59,6 +59,7 @@ describe('Loading Container', () => {
                     <LoadingContainer
                         data={null}
                         loadingState={bar.loading()}
+                        shouldShowLoadingState={true}
                     >
                         <div className="chart" />
                     </LoadingContainer>
@@ -78,6 +79,9 @@ describe('Loading Container', () => {
                 let expected = 'display:none;';
 
                 let childContainer = wrapper.find('.loading-container__children');
+
+                console.log(childContainer.html());
+
                 let actual = childContainer.html().match(/style="([^"]*)"/i)[1];
 
                 expect(actual).toEqual(expected);

--- a/src/charts/loading/LoadingContainer.test.js
+++ b/src/charts/loading/LoadingContainer.test.js
@@ -75,7 +75,7 @@ describe('Loading Container', () => {
             });
 
             it ('should include the loading class on the chart', () => {
-                let expected = 'visibility:hidden;';
+                let expected = 'display:none;';
 
                 let childContainer = wrapper.find('.loading-container__children');
                 let actual = childContainer.html().match(/style="([^"]*)"/i)[1];

--- a/src/charts/stackedArea/Readme.md
+++ b/src/charts/stackedArea/Readme.md
@@ -17,7 +17,6 @@
     />
 ```
 
-
 ### With fixed width and height
 ```js
     const stackedAreaData = require('./stackedAreaChart.fixtures.js').default;
@@ -49,6 +48,15 @@
         customMouseOver={logMouseOver}
         customMouseMove={logMouseMoveTooltip}
         customMouseOut={logMouseOut}
+    />
+```
+
+### With loading state
+```js
+
+    <StackedArea
+        data={null}
+        shouldShowLoadingState={true}
     />
 ```
 

--- a/src/charts/stackedArea/StackedArea.js
+++ b/src/charts/stackedArea/StackedArea.js
@@ -124,15 +124,6 @@ class StackedArea extends React.Component {
         shouldShowLoadingState: false,
     }
 
-    constructor(props) {
-        super(props);
-
-        // We want to make this throw an error if no data is provided
-        if (!props.data && !props.shouldShowLoadingState) {
-            throw new Error('Data is required!');
-        }
-    }
-
     componentDidMount() {
         if (this.props.data !== null) {
             this._createChart();

--- a/src/charts/stackedArea/StackedArea.js
+++ b/src/charts/stackedArea/StackedArea.js
@@ -125,17 +125,21 @@ class StackedArea extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.data !== null) {
-            this._createChart();
+        if (!this.props.shouldShowLoadingState) {
+            if (this.props.data !== null) {
+                this._createChart();
+            }
         }
     }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.data === null && this.props.data) {
-            this._createChart();
-        } else {
-            this._updateChart();
-            this.props.createTooltip();
+    componentDidUpdate() {
+        if (!this.props.shouldShowLoadingState) {
+            if (!this._chart) {
+                this._createChart();
+            } else {
+                this._updateChart();
+                this.props.createTooltip();
+            }
         }
     }
 

--- a/src/charts/stackedArea/StackedArea.js
+++ b/src/charts/stackedArea/StackedArea.js
@@ -9,7 +9,7 @@ class StackedArea extends React.Component {
         /**
          * Internally used, do not overwrite.
          */
-        data: PropTypes.arrayOf(PropTypes.any).isRequired,
+        data: PropTypes.arrayOf(PropTypes.any),
 
         /**
          * Exposes the constants to be used to force the x axis to respect a
@@ -128,12 +128,31 @@ class StackedArea extends React.Component {
         super(props);
 
         // We want to make this throw an error if no data is provided
-        if (!props.data) {
+        if (!props.data && !props.shouldShowLoadingState) {
             throw new Error('Data is required!');
         }
     }
 
     componentDidMount() {
+        if (this.props.data !== null) {
+            this._createChart();
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.data === null && this.props.data) {
+            this._createChart();
+        } else {
+            this._updateChart();
+            this.props.createTooltip();
+        }
+    }
+
+    componentWillUnmount() {
+        this.props.chart.destroy(this._rootNode);
+    }
+
+    _createChart() {
         this._chart = this.props.chart.create(
             this._rootNode,
             this.props.data,
@@ -141,19 +160,13 @@ class StackedArea extends React.Component {
         );
     }
 
-    componentDidUpdate() {
+    _updateChart() {
         this.props.chart.update(
             this._rootNode,
             this.props.data,
             this._getChartConfiguration(),
             this._chart
         );
-
-        this.props.createTooltip();
-    }
-
-    componentWillUnmount() {
-        this.props.chart.destroy(this._rootNode);
     }
 
     /**

--- a/src/charts/stackedArea/StackedArea.test.js
+++ b/src/charts/stackedArea/StackedArea.test.js
@@ -12,13 +12,7 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('Stacked Area Chart', () => {
 
     describe('render', () => {
-
-        describe('when data is not passed', () => {
-            it('should throw an error', () => {
-                expect(() => shallow(<StackedArea data={[]} />)).toThrow();
-            });
-        });
-
+        
         describe('when data passed in', () => {
             let createSpy;
 

--- a/src/charts/stackedArea/stackedAreaChart.test.js
+++ b/src/charts/stackedArea/stackedAreaChart.test.js
@@ -24,18 +24,6 @@ describe('Stacked Area Chart', () => {
                 });
             });
 
-            describe('when the Data is not passed', () => {
-                it('should throw an error with undefined data', () => {
-                    expect(() => {
-                        stackedArea.create(
-                            anchor,
-                            undefined,
-                            {}
-                        );
-                    }).toThrowError('Data must be defined');
-                });
-            });
-
             describe('when a non-supported method is passed', () => {
                 it('should throw an error', () => {
                     expect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6825,6 +6825,13 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+path@^0.12.7:
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
+  dependencies:
+    process "^0.11.1"
+    util "^0.10.3"
+
 pause-stream@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"


### PR DESCRIPTION
Fixes loading states style/bugs and adds them to demos

## Description
The initial styles added to the loading states so that they correctly fill the intended space before the charts load. It also delays creating the chart until there is data, and fixes some other errors that I ran into when adding them to the demos.

## How Has This Been Tested?
Ran existing tests and manually checked the styleguide.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
