### PR TITLE
Fixed links in demos to charts and corrected demos local port

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ In order to generate the demos and see the documentation for the library you wou
     `yarn run styleguide`
 
 
-This process will generate the styleguide and show it in ``localhost:6006``. You can use this demos as your testing platform when creating new charts.
+This process will generate the styleguide and show it in ``localhost:6060``. You can use this demos as your testing platform when creating new charts.
 
 
 ## Modifying a chart
@@ -140,7 +140,7 @@ The build sequence consists of a small set of [Node][node] tasks. While you'll p
 | `yarn run start`             | Start the development process that is going to transpile the files
 | `yarn run test`              | Run the Jest runner to see if the tests are running
 | `yarn run test:watch`        | Start the Jest runner that will test the project and keep watching for changes.
-| `yarn run styleguide`        | Serves the demos in localhost:6006.
+| `yarn run styleguide`        | Serves the demos in localhost:6060.
 | `yarn run styleguide:build`  | Builds the styleguide.
 | `yarn run build`             | Build everything and generate the distribution version of the charts.
 | `yarn run lint`              | Runs the eslint linter

--- a/README.md
+++ b/README.md
@@ -90,16 +90,16 @@ Read more in the [license document][licenseGithub]
 [homepage]: https://eventbrite.github.io/britecharts-react/
 [testProject]: https://github.com/Golodhros/britecharts-react-test-project
 
-[stackedAreaDemo]: https://eventbrite.github.io/britecharts-react/#stacked-area-chart "Check the Demo"
+[stackedAreaDemo]: https://eventbrite.github.io/britecharts-react/#stackedarea "Check the Demo"
 [stackedAreaImg]: https://raw.githubusercontent.com/eventbrite/britecharts-react/master/src/docs/images/thumbnails/stacked-area.png
 
-[barChartDemo]: https://eventbrite.github.io/britecharts-react/#bar-chart "Check the Demo"
+[barChartDemo]: https://eventbrite.github.io/britecharts-react/#bar "Check the Demo"
 [barChartImg]: https://raw.githubusercontent.com/eventbrite/britecharts-react/master/src/docs/images/thumbnails/bar-chart.png
 
-[donutChartDemo]: https://eventbrite.github.io/britecharts-react/#donut-chart "Check the Demo"
+[donutChartDemo]: https://eventbrite.github.io/britecharts-react/#donut "Check the Demo"
 [donutChartImg]: https://raw.githubusercontent.com/eventbrite/britecharts-react/master/src/docs/images/thumbnails/donut-chart.png
 
-[lineChartDemo]: https://eventbrite.github.io/britecharts-react/#line-chart "Check the Demo"
+[lineChartDemo]: https://eventbrite.github.io/britecharts-react/#line "Check the Demo"
 [lineChartImg]: https://raw.githubusercontent.com/eventbrite/britecharts-react/master/src/docs/images/thumbnails/line-chart.png
 
 [legendDemo]: https://eventbrite.github.io/britecharts-react/#legend "Check the Demo"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated readme's image-to-chart anchor tags. They are currently not working (only legend and tooltip work). Also the localhost for demos is `6060` not, `6006` - fixed that as well.

## Motivation and Context
Noticed a problem with the demo images not pointing to the proper IDs.

## How Has This Been Tested?
Ran tests and links.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
