### PR TITLE
Allow setChartProperty to handle empty string values

### DIFF
--- a/src/charts/helpers/configuration.js
+++ b/src/charts/helpers/configuration.js
@@ -4,7 +4,7 @@ const isEventConfig = (configName) => britechartsCustomEvents.indexOf(configName
 const isNotEventConfig = (configName) => !isEventConfig(configName);
 
 const setChartProperty = (chart, configuration, key) => {
-    if (configuration[key]) {
+    if (configuration[key] || typeof configuration[key] === 'string') {
         chart[key](configuration[key]);
     }
 };

--- a/src/charts/helpers/configuration.test.js
+++ b/src/charts/helpers/configuration.test.js
@@ -1,0 +1,15 @@
+import { applyConfiguration } from './configuration';
+
+describe('Configuration', () => {
+    it('should allow setting empty string', () => {
+        const expected = '';
+        const mockChart = {
+            'expected': (value) => {
+                mockChart._expected = value;
+            },
+        };
+        let actual = applyConfiguration(mockChart, { expected: '' })._expected;
+
+        expect(actual).toEqual(expected);
+    });
+});

--- a/src/charts/line/Readme.md
+++ b/src/charts/line/Readme.md
@@ -50,7 +50,7 @@
         data={lineData.fiveTopics()}
         render={renderLine}
         topicLabel="topics"
-        title="Demo Title"
+        title=""
     />
 ```
 


### PR DESCRIPTION
Fixes Issue: #132 
Allow setChartProperty to handle empty string values, 

## Description
In the setChartProperty if statement I add a check if the value is a string to allow for empty string being passed to the chart API

## Motivation and Context
Some Britechart config API has a setting for emptry string.
Example the [tooltip title ](http://eventbrite.github.io/britecharts/module-Tooltip.html#.title__anchor)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
 - Updated the styleguide with an empty tooltip
 - Tested all charts in styleguide

```
Browser Name and version: Chrome 65.0.3325
Operating System and version: MacOs 10.13.3
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
