### PR TITLE
Move _setRef method declaration to class constructor

### DIFF
--- a/src/charts/tooltip/Tooltip.js
+++ b/src/charts/tooltip/Tooltip.js
@@ -117,6 +117,8 @@ export default class Tooltip extends React.Component {
                 customMouseOver: this._handleMouseOver.bind(this),
             });
         }
+
+        this._setRef = this._setRef.bind(this);
     }
 
     state = {
@@ -210,7 +212,7 @@ export default class Tooltip extends React.Component {
 
     render() {
         return (
-            <div className="tooltip-chart-wrapper" ref={this._setRef.bind(this)}>
+            <div className="tooltip-chart-wrapper" ref={this._setRef}>
                 {this.childChart}
             </div>
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The declaration of the `_setRef` method to reference the `componentNode` for the `Tooltip` component has been moved from the `render` method to the class constructor using the recommended pattern in the React docs for [Callback Refs](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using `britecharts-react` in a project using `react-router` to handle the routing process the chart UI breaks every time the same route is visited or the link to it clicked while the route is still active.

This seems to be caused by the way `react-router` handles the component rendering for already rendered components, losing the reference and passing the `componentNode` parameter as null, breaking the chart.

You can see the error happening in [this prototype](https://codesandbox.io/s/4k76jy9z4)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
For the testing process I created a clean local project using `create-react-app` and npm linked the local version of `britecharts-react` with the changes applied to the code.

I also ran the projects unit tests and they all are still passing without any issue as expected since the changes only cover syntax/pattern issues.

## Screenshots (if appropriate):
[Prototype | Demo](https://codesandbox.io/s/4k76jy9z4)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
