### PR TITLE
Fix - plop generator parsing error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
       "email": "golodhros@gmail.com"
     },
     {
+      "name": "Daler Asrorov",
+      "email": "asrorids@gmail.com"
+    },
+    {
       "name": "Jaylum Chen",
       "email": "jaylum@eventbrite.com"
     },
     {
       "name": "Amber Rockwood",
       "email": "arockwood@eventbrite.com"
-    },
-    {
-      "name": "Daler Asrorov",
-      "email": "daler.asrorov@eventbrite.com"
     },
     {
       "name": "Sun Dai",
@@ -99,7 +99,7 @@
     "nodemon": "^1.18.6",
     "npm": "^6.4.1",
     "path": "^0.12.7",
-    "plop": "^2.1.0",
+    "plop": "^2.2.0",
     "prop-types": "^15.6.2",
     "react": "^16.6.1",
     "react-dev-utils": "^6.1.1",

--- a/src/charts/template/Component.test.js
+++ b/src/charts/template/Component.test.js
@@ -1,189 +1,232 @@
-import React from 'react';
-import { shallow, mount } from 'enzyme';
-
-import {{ pascalCase componentName }} from './{{pascalCase componentName}}';
-import {{ camelCase componentName }}Data from './{{camelCase componentName}}Chart.fixtures';
-
-import {{ camelCase componentName }} from './{{camelCase componentName}}Chart';
+import {{camelCase componentName}}Data from './{{camelCase componentName}}Chart.fixtures';
+import {{camelCase componentName}} from './{{camelCase componentName}}Chart';
 
 describe('{{titleCase componentName}} Chart', () => {
-
-    describe('render', () => {
-
-        describe('when data passed in', () => {
-            let createSpy;
-
-            beforeEach(() => {
-                createSpy = jest.spyOn({{ camelCase componentName }}, 'create');
-        });
-
-        afterEach(() => {
-            createSpy.mockReset();
-            createSpy.mockRestore();
-        });
-
-        it('should call the create method or the chart', () => {
-            const dataSet = {{ camelCase componentName }
-        }Data.firstDataMethod();
-
-        mount(< {{ pascalCase componentName }} chart = {{ openBrace }}{{ camelCase componentName }}{{ closeBrace }} data = { dataSet } />);
-
-let expected = 1;
-let actual = createSpy.mock.calls.length;
-
-expect(actual).toEqual(expected);
-            });
-
-it('should call the create method or the chart with the container as the first argument', () => {
-    const dataSet = {{ camelCase componentName }
-}Data.firstDataMethod();
-
-const wrapper = mount(< {{ pascalCase componentName }} chart = {{ openBrace }}{ { camelCase componentName } } { { closeBrace } } data = { dataSet } />);
-
-let expected = wrapper.find('.{{dashCase componentName}}-container').instance();
-let actual = createSpy.mock.calls[0][0];
-
-expect(actual).toEqual(expected);
-            });
-
-it('should call the create method or the chart with the configuration object as the second argument', () => {
-    const dataSet = {{ camelCase componentName }
-}Data.firstDataMethod();
-
-mount(< {{ pascalCase componentName }} chart = {{ openBrace }}{{ camelCase componentName }}{{ closeBrace }} data = { dataSet } />);
-
-let expectedData = dataSet;
-let actualData = createSpy.mock.calls[0][1];
-
-expect(actualData).toEqual(expectedData);
-            });
-
-it('should allow setting width', () => {
-    const dataSet = {{ camelCase componentName }
-}Data.firstDataMethod();
-let expected = 500;
-
-mount(
-                    < {{ pascalCase componentName }}
-    chart = {{ openBrace }}{{ camelCase componentName }}{{ closeBrace }}
-    data = { dataSet }
-                        width = { expected }
-    />
-                );
-
-let actual = createSpy.mock.calls[0][2].width;
-
-expect(actual).toEqual(expected);
-            });
-
-it('should allow setting height', () => {
-    const dataSet = {{ camelCase componentName }
-}Data.firstDataMethod();
-let expected = 500;
-
-mount(
-                    < {{ pascalCase componentName }}
-    chart = {{ openBrace }}{{ camelCase componentName }}{{ closeBrace }}
-    data = { dataSet }
-                        height = { expected }
-    />
-                );
-
-let actual = createSpy.mock.calls[0][2].height;
-
-expect(actual).toEqual(expected);
-            });
-        });
-    });
-
-describe('update', () => {
-
-    describe('when data changes', () => {
-        let updateSpy;
-
-        beforeEach(() => {
-            updateSpy = jest.spyOn({{ camelCase componentName }}, 'update');
-    });
-
-    afterEach(() => {
-        updateSpy.mockReset();
-        updateSpy.mockRestore();
-    });
-
-    it('should call the update method or the chart', () => {
-        const dataSet = {{ camelCase componentName }
-    }Data.firstDataMethod();
-    const wrapper = mount(< {{ pascalCase componentName }} chart = {{ openBrace }}{{ camelCase componentName }}{{ closeBrace }} data = { dataSet } />);
-
-// Changing properties should trigger a componentDidUpdate
-wrapper.setProps({
-    data: {{ camelCase componentName }}Data.secondDataMethod(),
-                });
-
-let expected = 1;
-let actual = updateSpy.mock.calls.length;
-
-expect(actual).toEqual(expected);
-            });
-
-it('should pass in the new data to the update method', () => {
-    const dataSet = {{ camelCase componentName }
-}Data.firstDataMethod();
-const wrapper = mount(< {{ pascalCase componentName }} chart = {{ openBrace }}{ { camelCase componentName } } { { closeBrace } } data = { dataSet } />);
-
-// Changing properties should trigger a componentDidUpdate
-wrapper.setProps({
-    data: {{ camelCase componentName }}Data.secondDataMethod(),
-                });
-
-let expected = {{ camelCase componentName }}Data.secondDataMethod().length;
-let actual = updateSpy.mock.calls[0][1].length;
-
-expect(actual).toEqual(expected);
-            });
-
-it('should pass in the new configuration to the update method', () => {
-    const dataSet = {{ camelCase componentName }
-}Data.firstDataMethod();
-const wrapper = mount(< {{ pascalCase componentName }} chart = {{ openBrace }}{ { camelCase componentName } } { { closeBrace } } data = { dataSet } />);
-const expected = 20;
-
-// Changing properties should trigger a componentDidUpdate
-wrapper.setProps({
-    width: expected,
-});
-
-let actual = updateSpy.mock.calls[0][2].width;
-
-expect(actual).toEqual(expected);
-            });
-        });
-    });
-
-describe('unmount', () => {
-    let createSpy;
+    let anchor;
 
     beforeEach(() => {
-        createSpy = jest.spyOn({{ camelCase componentName }}, 'destroy');
-});
+        anchor = document.createElement('div');
+    });
 
-afterEach(() => {
-    createSpy.mockReset();
-    createSpy.mockRestore();
-});
+    describe('create', () => {
 
-it('should call the destroy method or the chart', () => {
-    const dataSet = {{ camelCase componentName }
-}Data.firstDataMethod();
-const wrapper = mount(< {{ pascalCase componentName }} chart = {{ openBrace }}{ { camelCase componentName } } { { closeBrace } } data = { dataSet } />);
+        describe('when incorrect arguments are used', () => {
 
-wrapper.unmount();
+            describe('when the DOM element is not passed', () => {
+                it('should throw an error', () => {
+                    expect(() => {
+                      {{camelCase componentName}}.create(
+                            undefined,
+                            {{camelCase componentName}}Data.firstDataMethod(),
+                            {}
+                        );
+                    }).toThrowError('A root container is required');
+                });
+            });
 
-let expected = 1;
-let actual = createSpy.mock.calls.length;
+            describe('when a non-supported method is passed', () => {
+                it('should throw an error', () => {
+                    expect(() => {
+                        {{camelCase componentName}}.create(
+                            anchor,
+                            {{camelCase componentName}}Data.firstDataMethod(),
+                            { test: 'test' }
+                        );
+                    }).toThrowError('Method not supported by Britechart: test');
+                });
+            });
 
-expect(actual).toEqual(expected);
+            describe('when wrong event handlers are passed', () => {
+                it('should throw ane error', () => {
+                    const callback = jest.fn();
+
+                    expect(() => {
+                        {{camelCase componentName}}.create(
+                            anchor,
+                            {{camelCase componentName}}Data.firstDataMethod(),
+                            { customFakeEvent: callback }
+                        );
+                    }).toThrowError('Method not supported by Britechart: customFakeEvent');
+                });
+            });
+        });
+
+        describe('when proper arguments are passed', () => {
+
+            it('should set data as a DOM property', () => {
+                const expected = {{camelCase componentName}}Data.firstDataMethod().length;
+
+                {{camelCase componentName}}.create(anchor, {{camelCase componentName}}Data.firstDataMethod());
+
+                const actual = anchor.__data__.length;
+
+                expect(actual).toEqual(expected);
+            });
+
+            it('should set the width', () => {
+                const expected = 500;
+
+                const chart = {{camelCase componentName}}.create(
+                    anchor,
+                    {{camelCase componentName}}Data.firstDataMethod(),
+                    { width: expected }
+                );
+
+                const actual = chart.width();
+
+                expect(actual).toEqual(expected);
+            });
+
+            it('should set the height', () => {
+                const expected = 600;
+
+                const chart = {{camelCase componentName}}.create(
+                    anchor,
+                    {{camelCase componentName}}Data.firstDataMethod(),
+                    { height: expected }
+                );
+
+                const actual = chart.height();
+
+                expect(actual).toEqual(expected);
+            });
+
+            it('should set the margin', () => {
+                const expected = {
+                    top: 0,
+                    bottom: 1,
+                    left: 2,
+                    right: 3,
+                };
+
+                const chart = {{camelCase componentName}}.create(
+                    anchor,
+                    {{camelCase componentName}}Data.firstDataMethod(),
+                    { margin: expected }
+                );
+
+                const actual = chart.margin();
+
+                expect(actual).toEqual(expected);
+            });
+
+            /**
+             * The grid is not supported by every chart, and this test should only be included if necessary
+             */
+            it('should set the grid', () => {
+                const expected = 'vertical';
+
+                const chart = {{camelCase componentName}}.create(
+                    anchor,
+                    {{camelCase componentName}}Data.firstDataMethod(),
+                    { grid: expected }
+                );
+
+                const actual = chart.grid();
+
+                expect(actual).toEqual(expected);
+            });
+
+            describe('when event handlers are passed', () => {
+
+                it('should set customMouseOver callback', () => {
+                    const expected = jest.fn();
+
+                    const chart = {{camelCase componentName}}.create(
+                        anchor,
+                        {{camelCase componentName}}Data.firstDataMethod(),
+                        { customMouseOver: expected }
+                    );
+
+                    const actual = chart.on('customMouseOver');
+
+                    expect(actual).toEqual(expected);
+                });
+
+                it('should set customMouseMove callback', () => {
+                    const expected = jest.fn();
+
+                    const chart = {{camelCase componentName}}.create(
+                        anchor,
+                        {{camelCase componentName}}Data.firstDataMethod(),
+                        { customMouseMove: expected }
+                    );
+
+                    const actual = chart.on('customMouseMove');
+
+                    expect(actual).toEqual(expected);
+                });
+
+                it('should set customMouseOut callback', () => {
+                    const expected = jest.fn();
+
+                    const chart = {{camelCase componentName}}.create(
+                        anchor,
+                        {{camelCase componentName}}Data.firstDataMethod(),
+                        { customMouseOut: expected }
+                    );
+
+                    const actual = chart.on('customMouseOut');
+
+                    expect(actual).toEqual(expected);
+                });
+            });
+        });
+    });
+
+    describe('update', () => {
+
+        describe('when updating data', () => {
+
+            describe('when new data is passed', () => {
+                it('should update the data in the container', () => {
+                    const firstDataSet = {{camelCase componentName}}Data.firstDataMethod();
+                    const secondDataSet = {{camelCase componentName}}Data.secondDataMethod();
+                    let chart = {{camelCase componentName}}.create(anchor, firstDataSet, {});
+
+                    {{camelCase componentName}}.update(anchor, secondDataSet, {}, chart);
+
+                    const expected = secondDataSet.length;
+                    const actual = anchor.__data__.length;
+
+                    expect(actual).toEqual(expected);
+                });
+            });
+
+            describe('when new data is not passed', () => {
+                it('should keep the data in the container', () => {
+                    const dataSet = {{camelCase componentName}}Data.firstDataMethod();
+                    let chart = {{camelCase componentName}}.create(anchor, dataSet, {});
+
+                    {{camelCase componentName}}.update(anchor, [], {}, chart);
+
+                    const expected = dataSet.length;
+                    const actual = anchor.__data__.length;
+
+                    expect(actual).toEqual(expected);
+                });
+            });
+        });
+
+        describe('when updating configuration', () => {
+
+            describe('when new configuration is passed', () => {
+                it('should update the configuration in the chart', () => {
+                    const expected = 500;
+                    const firstWidth = 200;
+                    const chart = {{camelCase componentName}}.create(
+                        anchor,
+                        {{camelCase componentName}}Data.firstDataMethod(),
+                        { width: firstWidth }
+                    );
+
+                    {{camelCase componentName}}.update(anchor, [], { width: expected }, chart);
+
+                    const actual = chart.width();
+
+                    expect(actual).toEqual(expected);
+                });
+            });
         });
     });
 });
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,7 +2817,7 @@ debug@^4.0.1, debug@^4.1.0, debug@~4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -4778,7 +4778,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -6044,10 +6044,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -6055,27 +6051,9 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -6112,10 +6090,6 @@ lodash.isequal@^4.5.0:
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
 lodash.some@^4.6.0:
   version "4.6.0"
@@ -6720,13 +6694,12 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-plop@=0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/node-plop/-/node-plop-0.16.0.tgz#27141cc0b7de3a32e2e2471866d6968cc23efc24"
+node-plop@=0.17.3:
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/node-plop/-/node-plop-0.17.3.tgz#2e56543a159d6a378982cbebff81fcf08e9587f1"
   dependencies:
     change-case "^3.0.1"
     co "^4.6.0"
-    colors "^1.1.2"
     core-js "^2.4.1"
     del "^3.0.0"
     globby "^8.0.0"
@@ -6735,7 +6708,7 @@ node-plop@=0.16.0:
     isbinaryfile "^3.0.2"
     lodash.get "^4.4.2"
     mkdirp "^0.5.1"
-    pify "^3.0.0"
+    pify "^4.0.0"
     resolve "^1.2.0"
 
 node-pre-gyp@^0.10.0:
@@ -7245,6 +7218,17 @@ ora@^2.1.0:
     strip-ansi "^4.0.0"
     wcwidth "^1.0.1"
 
+ora@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-3.0.0.tgz#8179e3525b9aafd99242d63cc206fd64732741d0"
+  dependencies:
+    chalk "^2.3.1"
+    cli-cursor "^2.1.0"
+    cli-spinners "^1.1.0"
+    log-symbols "^2.2.0"
+    strip-ansi "^4.0.0"
+    wcwidth "^1.0.1"
+
 original@>=0.0.5, original@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/original/-/original-1.0.2.tgz#e442a61cffe1c5fd20a65f3261c26663b303f25f"
@@ -7587,6 +7571,10 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
+pify@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -7621,15 +7609,16 @@ pkg-up@2.0.0, pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-plop@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/plop/-/plop-2.1.0.tgz#260c26c8801e7835e199adfc6b0e2f07fe3085f7"
+plop@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/plop/-/plop-2.2.0.tgz#1ee64b37ca6d615dbe332115ec58bb66ab5cab59"
   dependencies:
     chalk "^1.1.3"
     interpret "^1.0.0"
     liftoff "^2.2.0"
     minimist "^1.2.0"
-    node-plop "=0.16.0"
+    node-plop "=0.17.3"
+    ora "^3.0.0"
     v8flags "^2.0.10"
 
 pluralize@^7.0.0:
@@ -8242,7 +8231,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR addresses the issue recently related to the upgrade to React 16. In this commit https://github.com/eventbrite/britecharts-react/pull/141, the `Component.test.js` file content has been changed and as a result, the `plop` parsing script failed to parse the template file. I put the content placed before that PR was made and the script, as before, creates all **7** files now.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves: https://github.com/eventbrite/britecharts-react/issues/151

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```shell
yarn install
yarn run plop
> ScatterPlot
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
