### PR TITLE
Fix StackedBar chart tooltip rendering

### DIFF
--- a/src/charts/stackedBar/Readme.md
+++ b/src/charts/stackedBar/Readme.md
@@ -19,6 +19,39 @@
     />
 ```
 
+### With default properties and tooltip
+```js
+    const stackedBarData = require('./stackedBarChart.fixtures.js').default;
+    const ResponsiveContainer = require('../helpers/responsiveContainer.js').default;
+    const margin = {
+        top: 60,
+        right: 30,
+        bottom: 60,
+        left: 70,
+    };
+
+    const renderStackedBar = (props) => (
+        <ResponsiveContainer
+            render={
+                ({width}) =>
+                    <StackedBar
+                        margin={margin}
+                        width={width}
+                        {...props}
+                    />
+            }
+        />
+    );
+
+    <Tooltip
+        data={stackedBarData.with3SourcesAndDates()}
+        render={renderStackedBar}
+        title="Tooltip Title"
+        dateLabel="key"
+        nameLabel="stack"
+    />
+```
+
 ### With loading state
 ```js
     <StackedBar

--- a/src/charts/stackedBar/stackedBarChart.fixtures.js
+++ b/src/charts/stackedBar/stackedBarChart.fixtures.js
@@ -46,6 +46,69 @@ const with3Sources = () => [
     },
 ];
 
+const with3SourcesAndDates = () => [
+    {
+        name: '2011-01-05',
+        stack: 'vivid',
+        value: 0,
+    },
+    {
+        name: '2011-01-06',
+        stack: 'vivid',
+        value: 4,
+    },
+    {
+        name: '2011-01-07',
+        stack: 'vivid',
+        value: 12,
+    },
+    {
+        name: '2011-01-08',
+        stack: 'vivid',
+        value: 23,
+    },
+    {
+        name: '2011-01-05',
+        stack: 'sparkling',
+        value: 18,
+    },
+    {
+        name: '2011-01-06',
+        stack: 'sparkling',
+        value: 16,
+    },
+    {
+        name: '2011-01-07',
+        stack: 'sparkling',
+        value: 10,
+    },
+    {
+        name: '2011-01-08',
+        stack: 'sparkling',
+        value: 0,
+    },
+    {
+        name: '2011-01-05',
+        stack: 'sunny',
+        value: 10,
+    },
+    {
+        name: '2011-01-06',
+        stack: 'sunny',
+        value: 20,
+    },
+    {
+        name: '2011-01-07',
+        stack: 'sunny',
+        value: 16,
+    },
+    {
+        name: '2011-01-08',
+        stack: 'sunny',
+        value: 25,
+    }
+];
+
 const with2Sources = () => [
     {
         name: 'Dazzling',
@@ -81,5 +144,6 @@ const with2Sources = () => [
 
 export default {
     with3Sources,
+    with3SourcesAndDates,
     with2Sources,
 };

--- a/src/charts/tooltip/Tooltip.js
+++ b/src/charts/tooltip/Tooltip.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import tooltip from './tooltipChart';
 
-const tooltipContainerSelector = '.metadata-group .vertical-marker-container';
+const tooltipContainerWithMarkerSelector = '.metadata-group .vertical-marker-container';
+const tooltipContainerSelector = '.metadata-group';
 
 
 export default class Tooltip extends React.Component {
@@ -174,10 +175,11 @@ export default class Tooltip extends React.Component {
     }
 
     componentDidUpdate() {
+        const tooltipWithMarkerContainer = this._rootNode.querySelector(tooltipContainerWithMarkerSelector);
         const tooltipContainer = this._rootNode.querySelector(tooltipContainerSelector);
 
-        if (tooltipContainer) {
-            this._chart = this.props.chart.update(tooltipContainer, this._getChartConfiguration(), this.state, this._chart);
+        if (tooltipWithMarkerContainer || tooltipContainer) {
+            this._chart = this.props.chart.update(tooltipWithMarkerContainer || tooltipContainer, this._getChartConfiguration(), this.state, this._chart);
         }
     }
 
@@ -186,10 +188,11 @@ export default class Tooltip extends React.Component {
     }
 
     _createTooltip = () => {
+        const tooltipWithMarkerContainer = this._rootNode.querySelector(tooltipContainerWithMarkerSelector);
         const tooltipContainer = this._rootNode.querySelector(tooltipContainerSelector);
 
-        if (tooltipContainer) {
-            this._chart = this.props.chart.create(tooltipContainer, this._getChartConfiguration());
+        if (tooltipWithMarkerContainer || tooltipContainer) {
+            this._chart = this.props.chart.create(tooltipWithMarkerContainer || tooltipContainer, this._getChartConfiguration());
         }
     }
 

--- a/src/charts/tooltip/Tooltip.js
+++ b/src/charts/tooltip/Tooltip.js
@@ -118,7 +118,7 @@ export default class Tooltip extends React.Component {
          *
          * @ignore
          */
-        data: PropTypes.object,
+        data: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
 
         /**
          * Internally used, do not overwrite.

--- a/src/charts/tooltip/Tooltip.test.js
+++ b/src/charts/tooltip/Tooltip.test.js
@@ -10,7 +10,13 @@ const FakeChart = () => (
     </div>
 );
 
+const FakeChartNoMarker = () => (
+    <div className="metadata-group" />
+);
+
 const renderFakeChart = () => <FakeChart />;
+
+const renderFakeChartNoMarker = () => <FakeChartNoMarker />;
 
 describe('tooltip', () => {
 
@@ -49,6 +55,21 @@ describe('tooltip', () => {
             );
 
             const expected = wrapper.find('.vertical-marker-container').instance();
+            const actual = createSpy.mock.calls[0][0];
+
+            expect(actual).toEqual(expected);
+        });
+
+
+        it('should call the create method or the chart with the container as the first argument when no vertical marker is present', () => {
+            const wrapper = mount(
+                <Tooltip
+                    chart={tooltip}
+                    render={renderFakeChartNoMarker}
+                />
+            );
+
+            const expected = wrapper.find('.metadata-group').instance();
             const actual = createSpy.mock.calls[0][0];
 
             expect(actual).toEqual(expected);


### PR DESCRIPTION
The tooltip rendering for the StackedBar chart is broken.

## Description
The Tooltip component was wrongly assuming all charts had the `.vertical-marker-container` DOM Node causing the charts with no vertical mark to return `null` to the query and not being able to load the tooltip.

This PR introduce the possibility to query the metadata container where no marker is included in the chart and pass that DOM Node instead.

## Motivation and Context
The PR solves the problem with broken tooltips. https://github.com/eventbrite/britecharts-react/issues/150

## How Has This Been Tested?
Unit tests has being created to test the case mentioned above.

## Screenshots:
![stackedbar-tooltip](https://user-images.githubusercontent.com/282903/58826930-d2285200-860f-11e9-902d-b4c897f701f1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Review the list before submitting your pull request -->
<!--- Leave the list intact for the code reviewer's use -->
- [x] Latest master code has been merged into this branch
- [x] No commented out code (if required, place // TODO above with explanation)
- [x] No linting issues
- [x] Build is successful
- [x] Updated the documentation
- [x] Added tests to cover changes
- [x] All new and existing tests passed
