### PR TITLE
Pass new data to chart when Tooltip component updates

### DIFF
--- a/src/charts/tooltip/Tooltip.js
+++ b/src/charts/tooltip/Tooltip.js
@@ -178,6 +178,10 @@ export default class Tooltip extends React.Component {
         const tooltipWithMarkerContainer = this._rootNode.querySelector(tooltipContainerWithMarkerSelector);
         const tooltipContainer = this._rootNode.querySelector(tooltipContainerSelector);
 
+        this.childChart = this.props.render({
+            data: this.props.data,
+        });
+
         if (tooltipWithMarkerContainer || tooltipContainer) {
             this._chart = this.props.chart.update(tooltipWithMarkerContainer || tooltipContainer, this._getChartConfiguration(), this.state, this._chart);
         }


### PR DESCRIPTION
The data is passed to the child chart when this changes.

## Description
Using the `componentDidUpdate` lifecycle method we can send the updated data passed to the Tooltip to the child chart, allowing the chart to render the new data when the tooltip is used.

## Motivation and Context
Charts using the Tooltip don't render fresh data because the tooltip is only passing the data on the initial render.

Closes issue #116 

## How Has This Been Tested?
All the unit tests had being run and a [test playground project](https://github.com/davegomez/britetest) was created.

## Screenshots (if appropriate):

![update-with-tooltip](https://user-images.githubusercontent.com/282903/59161050-62044b00-8aab-11e9-920f-9df461c5687c.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Review the list before submitting your pull request -->
<!--- Leave the list intact for the code reviewer's use -->
- [x] Latest master code has been merged into this branch
- [x] No commented out code (if required, place // TODO above with explanation)
- [x] No linting issues
- [x] Build is successful
- [x] Updated the documentation
- [ ] Added tests to cover changes
- [x] All new and existing tests passed
